### PR TITLE
Adds BRAINTRUST_API_URL env var support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `BRAINTRUST_API_URL` environment variable support for self-hosted deployments (#28)
+  - Allows configuring `base_url` via environment variable, similar to `BRAINTRUST_API_KEY`
+  - Configuration precedence: runtime opts > process config > app config > env var > default
+
 ## [0.2.0] - 2025-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Braintrust.configure(api_key: "sk-xxx")
 
 API keys can be created at [braintrust.dev/app/settings](https://www.braintrust.dev/app/settings?subroute=api-keys).
 
+### Self-Hosted Deployments
+
+For self-hosted Braintrust instances, set the API URL via environment variable:
+
+```bash
+export BRAINTRUST_API_KEY="sk-your-api-key"
+export BRAINTRUST_API_URL="https://braintrust.your-company.com"
+```
+
+Or configure in your application:
+
+```elixir
+config :braintrust,
+  api_key: System.get_env("BRAINTRUST_API_KEY"),
+  base_url: "https://braintrust.your-company.com"
+```
+
 ## Usage
 
 ### Projects

--- a/lib/braintrust/config.ex
+++ b/lib/braintrust/config.ex
@@ -14,7 +14,7 @@ defmodule Braintrust.Config do
   | Option | Type | Default | Description |
   |--------|------|---------|-------------|
   | `:api_key` | string | `BRAINTRUST_API_KEY` env | API key for authentication |
-  | `:base_url` | string | `https://api.braintrust.dev` | Base URL for API |
+  | `:base_url` | string | `BRAINTRUST_API_URL` env or `https://api.braintrust.dev` | Base URL for API |
   | `:timeout` | integer | `60_000` | Request timeout in ms |
   | `:max_retries` | integer | `2` | Maximum retry attempts |
 
@@ -55,7 +55,7 @@ defmodule Braintrust.Config do
   1. Runtime options (if provided)
   2. Process dictionary
   3. Application config
-  4. Environment variable (for `:api_key` only)
+  4. Environment variable (for `:api_key` and `:base_url`)
   5. Default value
 
   ## Examples
@@ -84,6 +84,7 @@ defmodule Braintrust.Config do
     opts[:base_url] ||
       Process.get(:braintrust_base_url) ||
       Application.get_env(:braintrust, :base_url) ||
+      System.get_env("BRAINTRUST_API_URL") ||
       @default_base_url
   end
 

--- a/test/braintrust/config_test.exs
+++ b/test/braintrust/config_test.exs
@@ -5,8 +5,9 @@ defmodule Braintrust.ConfigTest do
   alias Braintrust.Config
 
   setup do
-    # Store original env var
+    # Store original env vars
     original_api_key = System.get_env("BRAINTRUST_API_KEY")
+    original_api_url = System.get_env("BRAINTRUST_API_URL")
 
     # Clean up any process-level config
     Config.clear()
@@ -15,13 +16,18 @@ defmodule Braintrust.ConfigTest do
     Application.delete_env(:braintrust, :base_url)
     Application.delete_env(:braintrust, :timeout)
     Application.delete_env(:braintrust, :max_retries)
-    # Clear env var for tests
+    # Clear env vars for tests
     System.delete_env("BRAINTRUST_API_KEY")
+    System.delete_env("BRAINTRUST_API_URL")
 
     on_exit(fn ->
-      # Restore original env var
+      # Restore original env vars
       if original_api_key do
         System.put_env("BRAINTRUST_API_KEY", original_api_key)
+      end
+
+      if original_api_url do
+        System.put_env("BRAINTRUST_API_URL", original_api_url)
       end
     end)
 
@@ -59,6 +65,19 @@ defmodule Braintrust.ConfigTest do
       Application.put_env(:braintrust, :timeout, 15_000)
 
       assert Config.get(:timeout) == 15_000
+    end
+
+    test "env var takes precedence over default for base_url" do
+      System.put_env("BRAINTRUST_API_URL", "https://self-hosted.example.com")
+
+      assert Config.get(:base_url) == "https://self-hosted.example.com"
+    end
+
+    test "app config takes precedence over env var for base_url" do
+      System.put_env("BRAINTRUST_API_URL", "https://env.example.com")
+      Application.put_env(:braintrust, :base_url, "https://app.example.com")
+
+      assert Config.get(:base_url) == "https://app.example.com"
     end
   end
 


### PR DESCRIPTION
- Adds System.get_env("BRAINTRUST_API_URL") to base_url configuration lookup in Config.get(:base_url, opts)
- Updates module documentation to reflect env var support for both :api_key and :base_url
- Adds test coverage for env var precedence
- Updates README with self-hosted deployment examples
- Follows same pattern as BRAINTRUST_API_KEY

Closes #28